### PR TITLE
Fix investment field propagation bug

### DIFF
--- a/internal/models/transaction.go
+++ b/internal/models/transaction.go
@@ -150,10 +150,12 @@ func (t *Transaction) UpdateRecipientFromPayee() {
 }
 
 // UpdateInvestmentTypeFromInvestment ensures the InvestmentType field is set
+// UpdateInvestmentTypeFromLegacyField populates Investment when legacy parsers stored
+// this information in the Type field. If Investment is empty and Type is set, copy it.
 func (t *Transaction) UpdateInvestmentTypeFromLegacyField() {
-	if t.Investment == "" {
-		t.Investment = t.GetPartyName()
-	}
+        if t.Investment == "" && t.Type != "" {
+                t.Investment = t.Type
+        }
 }
 
 // UpdateDebitCreditAmounts populates the Debit and Credit fields based on the main Amount

--- a/internal/models/transaction_test.go
+++ b/internal/models/transaction_test.go
@@ -158,3 +158,23 @@ func TestStandardizeAmount(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateInvestmentTypeFromLegacyField(t *testing.T) {
+    t.Run("CopyFromType", func(t *testing.T) {
+        tx := &Transaction{Type: "Buy"}
+        tx.UpdateInvestmentTypeFromLegacyField()
+        assert.Equal(t, "Buy", tx.Investment)
+    })
+
+    t.Run("DoNotOverride", func(t *testing.T) {
+        tx := &Transaction{Investment: "Sell", Type: "Buy"}
+        tx.UpdateInvestmentTypeFromLegacyField()
+        assert.Equal(t, "Sell", tx.Investment)
+    })
+
+    t.Run("EmptyFields", func(t *testing.T) {
+        tx := &Transaction{}
+        tx.UpdateInvestmentTypeFromLegacyField()
+        assert.Equal(t, "", tx.Investment)
+    })
+}


### PR DESCRIPTION
## Summary
- fix logic in `UpdateInvestmentTypeFromLegacyField` to copy value from `Type`
- add unit tests for this behaviour

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.2)*

------
https://chatgpt.com/codex/tasks/task_e_68456816d384832595ba752e77fb0dd3