### PR TITLE
feat: add revolut-crypto parser and French locale support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-04-06
+
+### Added
+
+- Add `revolut-crypto` command to parse Revolut Crypto account statement CSV exports (French locale numbers and dates, supports `Achat` and `Récompense de staking` transaction types)
+- Add `revolut` parser support for French-localized CSV exports (headers and values normalized to English before parsing)
+
 ### Fixed
+
+- Fix `revolut-investment` parser failing on amounts with ISO 4217 currency prefix (e.g. `USD 2.84`)
+- Fix `revolut` command ignoring `output.format` config when `--format` flag is not passed
 
 - Fix all parsers outputting only positive amounts — debit transactions now correctly have negative amounts in CSV output (CAMT, PDF, Revolut, Visa Debit, Selma, Revolut Investment). The sign is applied in `TransactionBuilder.Build()` based on debit/credit direction.
 - Fix AI rate limiter dropping requests instead of throttling — replace non-blocking `Allow()` with blocking `Wait(ctx)` in both OpenRouter and Gemini clients so batch processing naturally paces requests at the configured rate instead of rejecting them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ CLI usage: `--format standard` or `--format icompta`. New formatters: implement 
 
 ### Directory Structure
 
-- `cmd/` - Cobra CLI commands (camt, pdf, batch, categorize, revolut, selma, debit, revolut-investment)
+- `cmd/` - Cobra CLI commands (camt, pdf, batch, categorize, revolut, revolut-crypto, selma, debit, revolut-investment)
 - `internal/` - Core application logic:
   - `*parser/` packages - Format-specific parsers with `adapter.go` implementing the interface
   - `categorizer/` - Transaction categorization with AI integration

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/fjacquet/camt-csv)](https://github.com/fjacquet/camt-csv/releases/latest)
 [![Docker Pulls](https://img.shields.io/badge/docker-ghcr.io-blue)](https://github.com/fjacquet/camt-csv/pkgs/container/camt-csv)
 
-CAMT-CSV converts financial statement formats (CAMT.053 XML, PDF, Revolut CSV, Selma CSV) into standardized CSV files with AI-powered transaction categorization.
+CAMT-CSV converts financial statement formats (CAMT.053 XML, PDF, Revolut CSV, Revolut Crypto CSV, Selma CSV) into standardized CSV files with AI-powered transaction categorization.
 
 ## Installation
 
@@ -46,6 +46,9 @@ camt-csv pdf -i statement.pdf -o output.csv
 
 # Revolut investment transactions
 camt-csv revolut-investment -i investments.csv -o output.csv
+
+# Revolut Crypto transactions
+camt-csv revolut-crypto -i crypto.csv -o output.csv
 
 # Selma investment CSV
 camt-csv selma -i selma.csv -o output.csv

--- a/cmd/revolut-crypto/convert.go
+++ b/cmd/revolut-crypto/convert.go
@@ -1,0 +1,21 @@
+// Package revolutcrypto handles Revolut Crypto statement conversion commands.
+package revolutcrypto
+
+import (
+	"fjacquet/camt-csv/cmd/common"
+	"fjacquet/camt-csv/internal/container"
+
+	"github.com/spf13/cobra"
+)
+
+// Cmd represents the revolut-crypto command.
+var Cmd = &cobra.Command{
+	Use:   "revolut-crypto",
+	Short: "Convert Revolut Crypto CSV to CSV",
+	Long:  `Convert Revolut Crypto account statement CSV files to CSV format.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		common.RunConvert(cmd, args, container.RevolutCrypto, "Revolut Crypto")
+	},
+}
+
+func init() { common.RegisterFormatFlags(Cmd) }

--- a/cmd/revolut/convert.go
+++ b/cmd/revolut/convert.go
@@ -47,6 +47,10 @@ func revolutFunc(cmd *cobra.Command, _ []string) {
 		logger.Fatal("Container not initialized")
 	}
 
+	if format == "" {
+		format = appContainer.GetConfig().Output.Format
+	}
+
 	p, err := appContainer.GetParser(container.Revolut)
 	if err != nil {
 		logger.Fatalf("Error getting Revolut parser: %v", err)

--- a/database/creditors.yaml
+++ b/database/creditors.yaml
@@ -15,6 +15,7 @@ concur technologies, inc.: Virements
 coop pronto: Courses
 cpev lausanne: Pension
 cr twint laurent claude p majch: Virements
+cr twint matteo sorci: Virements
 cr twint romain joncour: Virements
 cr twint vladimir budimirovic: Virements
 dell sa: Salaire
@@ -45,6 +46,8 @@ kiro ai: Revenus Professionnels
 migros: Courses
 mutuel assurance maladie sa: Assurance Maladie
 obsidian: Revenus Professionnels
+paiement envoyé par frederic yvan joseph jacquet: Virements
+paiement envoyé par jacquet florence caroline isabelle &amp; frederic yvan joseph: Virements
 payment from frederic jacquet: Virements
 payment from frederic yvan joseph jacquet: Virements
 payment from jacquet florence caroline isabelle &amp; frederic yvan joseph: Virements
@@ -55,6 +58,17 @@ premium plan fee: Virements
 radisson blu hotel basel, basel ch: Vacances
 resultat de cloture: Revenus Financiers
 revenu titre    460782: Revenus Financiers
+revolut crypto - sol: Investissements
+revolut investment: Investissements
+revolut investment - aapl: Investissements
+revolut investment - asml: Investissements
+revolut investment - dell: Investissements
+revolut investment - dis: Investissements
+revolut investment - goog: Investissements
+revolut investment - jnj: Investissements
+revolut investment - msft: Investissements
+revolut investment - nee: Investissements
+revolut investment - slb: Investissements
 sbb cff ffs: Transports Publics
 selecta: Alimentation
 sword technologies sa: Salaire

--- a/database/debtors.yaml
+++ b/database/debtors.yaml
@@ -19,6 +19,7 @@ al cilento: Restaurants
 al volo pizzeria: Restaurants
 aletsch bahnen ag: Loisirs
 alphonse mellot, sancerre fr: Alimentation
+alpine lounge armachris: Restaurants
 amag, noville ch: Restaurants
 amavita montreux 100: Santé
 amavita montreux 10067, montreux ch: Santé
@@ -35,6 +36,7 @@ aquamed montreux sa, montreux ch: Santé
 aquamedmontreux: Santé
 aquatis hotel sa: Loisirs
 asloca montreux: Logement
+ass. paroissiale catho: Dons
 aswisscheese sarl, montreux ch: Alimentation
 au grotto: Restaurants
 autost aosta g.s.b./torin, o nord it: Voiture
@@ -55,9 +57,11 @@ belambra: Vacances
 berger paints: Pension
 berghotel schwarenbach, leukerbad ch: Vacances
 berghotel wildstrubel: Restaurants
+betterman labs: Courses
 bioberguen.ch: Courses
 bistrot saint d 4044671, 75paris 7 fr: Restaurants
 blarney castle & gardens: Transports Publics
+bloc carte/ch jacquet frederic yvan: Family
 boreal coffee shop: Restaurants
 boucherie la vallée: Alimentation
 boucherie-charcuteri: Alimentation
@@ -101,6 +105,7 @@ chalet swiss: Restaurants
 cheverny, chamonix-mont fr: Restaurants
 christ-3875, montreux ch: Shopping
 cidiverte schweiz gmbh, bern ch: Loisirs
+city parking: Voiture
 claude.ai subscription, anthropic.com us: Abonnements
 codeium: Abonnements
 comm.adm.valeurs: Frais Bancaires
@@ -114,12 +119,15 @@ coop: Courses
 coop mineraloel ag: Voiture
 coop pronto: Courses
 coop pronto 3499: Courses
+coop pronto 3521: Courses
 coop pronto 3521 montr: Courses
 coop pronto 3521, montreux ch: Courses
 coop pronto 3658 basel: Courses
 coop pronto 3721: Courses
 coop pronto 4062: Courses
 coop pronto 4062 sembr: Courses
+coop pronto 4107 biel/: Courses
+coop pronto 4238: Courses
 coop pronto 5460: Courses
 coop pronto 5463 sion: Courses
 coop pronto 5601 renen: Courses
@@ -147,6 +155,7 @@ cornavin-wc-publics: Utilités
 couleur et saveur, sancerre fr: Restaurants
 coursera: Éducation
 croix-roug* donation, paris fr: Dons
+croix-rouge vaudoise: Dons
 d e d sas di darensod al, gignod it: Alimentation
 damien bernal fujifilm: Divertissement
 darty mktplace 4899414, 93bondy fr: Shopping
@@ -211,8 +220,9 @@ fnac - montreux: Shopping
 fnac - montreux, montreux ch: Shopping
 fnac - rive: Shopping
 fnac montreux: Shopping
-fond. museo nazionale da, milano it: Pension
+fond. museo nazionale da, milano it: Shopping
 foodvisor, paris fr: Abonnements
+frais periodiques 01.02. -28.02.26: Loisirs
 frederic jacquet: Virements
 fun planet rennaz: Loisirs
 fun planet rennaz, rennaz ch: Loisirs
@@ -260,6 +270,7 @@ harringtons restaurant strand st dingle co kerry: Restaurants
 hbh frankfurt airport, frankfurt am de: Restaurants
 heberer ffm flgh acm: Restaurants
 heineken sports bar: Restaurants
+hfr riaz: Voiture
 hopital fribourgeois, fribourg ch: Santé
 hornbach: Mobilier
 hornbach baumarkt (sch: Mobilier
@@ -280,9 +291,12 @@ hotel weisses kreuz bergu, bergun/bravuo ch: Vacances
 hotel zermama: Vacances
 hotel zermama, zermatt ch: Vacances
 hotel-restaurant st-chris, bex ch: Pension
+hôtel le beausite: Utilités
 ifolor: Shopping
 ifolor gmbh, konstanz de: Shopping
+ikea: Mobilier
 ikea ag: Mobilier
+ikea sa aubonne 078: Mobilier
 ikea schweiz e-com, spreitenbach ch: Mobilier
 il bacio, renens ch: Restaurants
 imholz sport ag, andermatt ch: Sport
@@ -294,6 +308,7 @@ infomaniak network sa: Abonnements
 inglewood: Restaurants
 inglewood montreux: Restaurants
 inglewood montreux, montreux ch: Restaurants
+installations zinal: Équipement Maison
 interdiscount: Shopping
 interdiscount-4549 m: Shopping
 interdiscount-4549 mon: Shopping
@@ -320,6 +335,7 @@ l'osteria: Restaurants
 la bicyclette, bourges fr: Restaurants
 la bonne bouteille sas d: Restaurants
 la boucherie: Alimentation
+la brasserie: Restaurants
 la grange: Restaurants
 la grange bar: Restaurants
 la molisana: Restaurants
@@ -334,6 +350,7 @@ laederach schweiz ag, sion ch: Alimentation
 laiterie centrale d': Alimentation
 laiterie de gruyere, montreux ch: Alimentation
 lausanne sous-voies gare, lausanne ch: Sport
+le basilic: Restaurants
 le basilic, montreux ch: Alimentation
 le cerf rougement sa, rougemont ch: Restaurants
 le kamuy ramen isaka: Restaurants
@@ -477,6 +494,7 @@ nyx*sncfgaresetconnexio, paris fr: Transports Publics
 obsidian: Abonnements
 ochsner sport / 763, villeneuve vd ch: Sport
 ochsner sport 0653: Sport
+oelist: Restaurants
 openai: Abonnements
 openai *chatgpt subscr, dublin ie: Abonnements
 openai *chatgpt subscr, openai.com us: Abonnements
@@ -485,6 +503,7 @@ openrouter, inc, openrouter.ai us: Abonnements
 original levis store veve, vevey ch: Shopping
 osez sarl: Bien-être
 osteria italiana: Restaurants
+osteria papà nicola: Restaurants
 packtpub: Restaurants
 paddle.net* feedly, london gb: Abonnements
 paddle.net* n8n cloud1, lisboa pt: Abonnements
@@ -528,6 +547,8 @@ pms parking: Voiture
 pmt carte: Frais Bancaires
 pmt e-com apple.com/chde: Abonnements
 pmt e-com gamma.app: Abonnements
+pmt e-com le creuset aubonne: Mobilier
+pmt e-com milano centrale: Transports Publics
 pmt e-com publibike.ch: Transports Publics
 pmt e-com vma academy sarl: Formation
 pmt twint: Virements
@@ -545,8 +566,9 @@ radisson blu boulogne fo, boulogne-bill fr: Vacances
 radisson blu hotel basel, basel ch: Vacances
 radisson blu hotel lucern, luzern ch: Vacances
 radisson blu lyon fo, lyon fr .23 1': Vacances
-radisson blu milan fb, milano it: Pension
-radisson blu milan fo, milano it: Pension
+radisson blu milan fb, milano it: Vacances
+radisson blu milan fo, milano it: Vacances
+radisson hotel zuric: Vacances
 radisson hotel zurich air, rumlang ch: Assurances
 rapidapi, nokia.com us: Alimentation
 rapidapi, rapidapi.com us: Abonnements
@@ -572,6 +594,7 @@ restaurant huit: Restaurants
 restaurant huit, montreux ch: Restaurants
 restaurant i'ltoya, chavannes re ch: Restaurants
 restaurant iles: Restaurants
+restaurant la chamade: Restaurants
 restaurant la detente, corminboeuf ch: Restaurants
 restaurant la poste: Restaurants
 restaurant la rouvenaz sa, montreux ch: Restaurants
@@ -580,6 +603,7 @@ restaurant le: Restaurants
 restaurant le milan, lausanne ch: Restaurants
 restaurant les rosal: Restaurants
 restaurant oliobasilico, geneve ch: Restaurants
+restaurant quartier: Restaurants
 restaurant rinderhütte: Restaurants
 restaurant sushi kai: Pension
 restaurant-pizzeria, clarens ch: Restaurants
@@ -587,6 +611,7 @@ restaurantvieuxchampex, champex-lac ch: Restaurants
 restoroute gruyere, avry-devant-p ch: Restaurants
 retail inmotion: Pension
 retrait: Divers
+retrait avenue des alpes: Divers
 retrait bcv montreux 1: Divers
 retrait bcv montreux 2: Divers
 retrait bcv montreux forum: Divers
@@ -600,6 +625,8 @@ retrait ubs basel marktplatz: Divers
 retrait ubs genève cornavin: Divers
 retrait ubs montreux: Divers
 revolut bank uab: Virements
+revolut crypto - btc: Investissements
+revolut investment - ibm: Investissements
 rewe: Courses
 rhb webshop: Transports Publics
 rhb webshop, chur ch: Transports Publics
@@ -614,7 +641,9 @@ rochestown park hotel: Vacances
 romande energie sa: Utilités
 royalty entertainmen: Loisirs
 sarl ruelle, saint-georges fr: Restaurants
+sas hotels: Vacances
 sbb: Transports Publics
+sbb biel wc: Transports Publics
 sbb cff ffs: Transports Publics
 sbb cff ffs mobile ticket, bern ch: Transports Publics
 sbb chur wc: Utilités
@@ -632,6 +661,7 @@ selecta merchant vendi, kirchberg ch: Alimentation
 serafe ag: Taxes
 serper: Non Classé
 shell: Voiture
+sherpa: Restaurants
 signal: Utilités
 slalom sport, zermatt ch: Sport
 smeetz sa: Loisirs
@@ -643,6 +673,7 @@ socar: Voiture
 socar station-servic: Voiture
 socar station-service, montreux ch: Voiture
 souscr.    460782: Abonnements
+sp fightwear: Shopping
 sp plaud.ai fr, wan chai hk: Abonnements
 spar: Bien-être
 spielkiste verkehrshau: Shopping
@@ -650,6 +681,7 @@ sports 2000: Sport
 sports 2000, montreux ch: Sport
 sportxx: Sport
 starbucks: Restaurants
+stow your bags: Restaurants
 suisse rando: Loisirs
 sumup  *fleurs de th: Restaurants
 sumup  *restaurant d: Restaurants
@@ -666,6 +698,7 @@ swiss alps gastro, andermatt ch: Restaurants
 swisscom grossunterneh: Utilités
 taxi franck: Voiture
 tea-room martel: Restaurants
+tefal aubonne: Équipement Maison
 temu: Shopping
 the grill: Restaurants
 the grill, le grand-saco ch: Restaurants
@@ -694,12 +727,15 @@ vaudoise generale: Assurances
 vaudoise vie compagnie: Assurances
 verkehrshaus der schw: Loisirs
 verkehrshaus der schweiz: Loisirs
+vers le compte d'investissement: Investissements
 victorinox https://www: Shopping
 victorinox retail schweiz, ibach ch: Shopping
 vir twint beexfit: Virements
 vir twint david schraner: Virements
 vir twint david staeheli: Virements
+vir twint matteo sorci: Virements
 vir twint medeci chinoise han sa: Virements
+vir twint medecine chinoise 3: Virements
 vir twint medecine han: Virements
 vir twint medecine han 2: Virements
 vir twint patrick marki: Virements
@@ -710,6 +746,7 @@ vivatk156296636267, bologna it: Shopping
 volg laden berguen: Courses
 volken sport gmbh store, fiesch ch: Sport
 vroom, geneve ch: Restaurants
+wal*westhive: Courses
 wc restaurant mgp: Utilités
 wfhland / fabric, fabric.so us: Abonnements
 wikimedia ch: Dons
@@ -731,3 +768,4 @@ zattoo, zurich ch: Abonnements
 zbag restaurant mgp: Restaurants
 zbag schluhmatte billett, zermatt ch: Transports Publics
 zenhäusern frères sa: Restaurants
+zum braunen mutz: Restaurants

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # Product Requirements Document: camt-csv
 
-**Version:** 1.4 (current)
-**Last updated:** 2026-02-23
+**Version:** 2.4 (current)
+**Last updated:** 2026-04-06
 **Status:** Active development
 
 ---
@@ -60,8 +60,11 @@ Go developers and financial data engineers who need a reference implementation o
 | Output iCompta-compatible CSV | ✅ Shipped (v1.2) |
 | Four-tier AI categorization with safety controls | ✅ Shipped (v1.2) |
 | Standard CSV trimmed to useful 29 columns | ✅ Shipped (v1.3) |
-| Eliminate batch/single-file split (folder detection) | 🔵 v1.4 in progress |
-| iCompta format as default (no flag needed) | 🔵 v1.4 in progress |
+| Eliminate batch/single-file split (folder detection) | ✅ Shipped (v1.4) |
+| iCompta format as default (no flag needed) | ✅ Shipped (v1.4) |
+| Multi-LLM provider support (OpenRouter + Gemini) | ✅ Shipped (v2.3.1) |
+| Revolut Crypto CSV parser | ✅ Shipped (v2.4.0) |
+| French-localized Revolut CSV support | ✅ Shipped (v2.4.0) |
 
 ### Non-Goals
 
@@ -82,6 +85,7 @@ Go developers and financial data engineers who need a reference implementation o
 | `revolut` | Revolut CSV export | Revolut CHF / EUR current and savings accounts |
 | `revolut-investment` | Revolut Investment CSV | Revolut Stocks/ETF portfolio |
 | `selma` | Selma CSV export | Selma automated investment accounts |
+| `revolut-crypto` | Revolut Crypto CSV | Revolut Crypto account (buy/staking, French locale) |
 | `debit` | Generic debit CSV | Generic debit card transaction exports |
 
 ### CAMT.053 Specifics
@@ -233,6 +237,9 @@ Automatically processes all matching files in the folder (non-recursive). `--out
 | ADR-015 | AI safety: rate limit, backoff, auto-learn OFF default, confidence scores |
 | ADR-016 | Standard CSV trimmed to 29 columns (removed 6 unused columns) |
 | ADR-017 | Input auto-detection: file → single, folder → multi (v1.4) |
+| ADR-018 | Multi-LLM provider support (OpenRouter + Gemini) |
+| ADR-019 | AI response parsing robustness |
+| ADR-020 | Preserve parser-internal categories |
 
 Full ADR files: `docs/adr/`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,8 @@ internal/
 │   └── constitution.go   # Constitution loading
 ├── camtparser/           # CAMT.053 XML parser
 ├── pdfparser/           # PDF statement parser
-├── revolutparser/       # Revolut CSV parser
+├── revolutparser/       # Revolut CSV parser (English + French locales)
+├── revolutcryptoparser/ # Revolut Crypto account parser (French locale)
 ├── revolutinvestmentparser/ # Revolut investment parser
 ├── selmaparser/         # Selma investment parser
 └── debitparser/         # Generic debit CSV parser

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -18,8 +18,8 @@ CAMT-CSV is a powerful command-line tool that converts various financial stateme
 
 ### Key Features
 
-- **Multi-format Support**: CAMT.053 XML, PDF bank statements, Revolut CSV, Revolut Investment CSV, Selma investment CSV, and generic debit CSV
-- **Smart Categorization**: Three-tier strategy pattern using direct mapping, keyword matching, and AI fallback with auto-learning
+- **Multi-format Support**: CAMT.053 XML, PDF bank statements, Revolut CSV (English and French locales), Revolut Crypto CSV, Revolut Investment CSV, Selma investment CSV, and generic debit CSV
+- **Smart Categorization**: Four-tier strategy pattern using direct mapping, keyword matching, semantic search, and AI fallback with auto-learning
 - **Dependency Injection Architecture**: Clean architecture with explicit dependencies, eliminating global state
 - **Hierarchical Configuration**: Viper-based configuration system with config files, environment variables, and CLI flags
 - **Batch Processing**: Process multiple files at once with automatic format detection
@@ -174,7 +174,7 @@ All commands support these global flags and configuration options:
 
 ### Command-Specific Flags
 
-#### Parser Commands (camt, pdf, revolut, revolut-investment, selma, debit)
+#### Parser Commands (camt, pdf, revolut, revolut-crypto, revolut-investment, selma, debit)
 
 | CLI Flag | Default | Description |
 |----------|---------|-------------|
@@ -277,6 +277,7 @@ All CAMT-CSV commands follow this pattern:
 | `camt` | Convert CAMT.053 XML files | XML bank statements |
 | `pdf` | Convert PDF bank statements | PDF files |
 | `revolut` | Process Revolut CSV exports | Revolut CSV format |
+| `revolut-crypto` | Process Revolut Crypto account CSV exports | Revolut Crypto CSV (French locale) |
 | `revolut-investment` | Process Revolut investment transactions | Revolut investment CSV format |
 | `selma` | Process Selma investment files | Selma CSV format |
 | `debit` | Process generic debit CSV files | Generic CSV format |
@@ -303,7 +304,13 @@ All CAMT-CSV commands follow this pattern:
    ./camt-csv revolut -i revolut_export.csv -o processed.csv
    ```
 
-4. **Process Revolut investment transactions:**
+4. **Process Revolut Crypto transactions:**
+
+   ```bash
+   ./camt-csv revolut-crypto -i crypto_export.csv -o processed.csv
+   ```
+
+5. **Process Revolut investment transactions:**
 
    ```bash
    ./camt-csv revolut-investment -i investment_export.csv -o processed.csv

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -15,6 +15,7 @@ import (
 	"fjacquet/camt-csv/internal/logging"
 	"fjacquet/camt-csv/internal/parser"
 	"fjacquet/camt-csv/internal/pdfparser"
+	"fjacquet/camt-csv/internal/revolutcryptoparser"
 	"fjacquet/camt-csv/internal/revolutinvestmentparser"
 	"fjacquet/camt-csv/internal/revolutparser"
 	"fjacquet/camt-csv/internal/selmaparser"
@@ -29,6 +30,7 @@ const (
 	PDF               ParserType = "pdf"
 	Revolut           ParserType = "revolut"
 	RevolutInvestment ParserType = "revolut-investment"
+	RevolutCrypto     ParserType = "revolut-crypto"
 	Selma             ParserType = "selma"
 	Debit             ParserType = "debit"
 )
@@ -162,6 +164,11 @@ func NewContainer(cfg *config.Config) (*Container, error) {
 	revolutInvestmentParser := revolutinvestmentparser.NewAdapter(logger)
 	revolutInvestmentParser.SetCategorizer(cat)
 	parsers[RevolutInvestment] = revolutInvestmentParser
+
+	// Revolut Crypto parser
+	revolutCryptoParser := revolutcryptoparser.NewAdapter(logger)
+	revolutCryptoParser.SetCategorizer(cat)
+	parsers[RevolutCrypto] = revolutCryptoParser
 
 	// Selma parser
 	selmaParser := selmaparser.NewAdapter(logger)

--- a/internal/revolutcryptoparser/adapter.go
+++ b/internal/revolutcryptoparser/adapter.go
@@ -1,0 +1,111 @@
+package revolutcryptoparser
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"fjacquet/camt-csv/internal/logging"
+	"fjacquet/camt-csv/internal/models"
+	"fjacquet/camt-csv/internal/parser"
+)
+
+// Adapter implements the parser.FullParser interface for Revolut Crypto CSV files.
+type Adapter struct {
+	parser.BaseParser
+}
+
+// NewAdapter creates a new Adapter for the revolutcryptoparser.
+func NewAdapter(logger logging.Logger) *Adapter {
+	return &Adapter{
+		BaseParser: parser.NewBaseParser(logger),
+	}
+}
+
+// Parse reads data from the provided io.Reader and returns a slice of Transaction models.
+func (a *Adapter) Parse(ctx context.Context, r io.Reader) ([]models.Transaction, error) {
+	return ParseWithCategorizer(r, a.GetLogger(), a.GetCategorizer())
+}
+
+// ConvertToCSV implements parser.FullParser.ConvertToCSV.
+func (a *Adapter) ConvertToCSV(ctx context.Context, inputFile, outputFile string) error {
+	return a.ConvertToCSVDefault(ctx, inputFile, outputFile, a.Parse)
+}
+
+// ValidateFormat checks if a file is a valid Revolut Crypto CSV file.
+func (a *Adapter) ValidateFormat(file string) (bool, error) {
+	f, err := os.Open(file) // #nosec G304 -- CLI tool requires user-provided file paths
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			a.GetLogger().WithError(err).Warn("Failed to close file during format validation",
+				logging.Field{Key: "file", Value: file})
+		}
+	}()
+
+	header, err := csv.NewReader(f).Read()
+	if err != nil || len(header) < 7 {
+		return false, nil
+	}
+	// Check for the three distinctive headers that differ from standard Revolut CSV
+	required := map[string]bool{"Symbol": false, "Type": false, "Date": false}
+	for _, h := range header {
+		if _, ok := required[strings.TrimSpace(h)]; ok {
+			required[strings.TrimSpace(h)] = true
+		}
+	}
+	for _, found := range required {
+		if !found {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// BatchConvert converts all Revolut Crypto CSV files in inputDir to outputDir.
+func (a *Adapter) BatchConvert(ctx context.Context, inputDir, outputDir string) (int, error) {
+	logger := a.GetLogger()
+	if logger == nil {
+		logger = logging.NewLogrusAdapter("info", "text")
+	}
+
+	if err := os.MkdirAll(outputDir, 0750); err != nil {
+		return 0, fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	files, err := os.ReadDir(inputDir)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read input directory: %w", err)
+	}
+
+	count := 0
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(strings.ToLower(file.Name()), ".csv") {
+			continue
+		}
+
+		inputPath := filepath.Join(inputDir, file.Name())
+		outputPath := filepath.Join(outputDir, file.Name())
+
+		valid, err := a.ValidateFormat(inputPath)
+		if err != nil || !valid {
+			logger.WithError(err).Warn("Skipping invalid file", logging.Field{Key: "file", Value: file.Name()})
+			continue
+		}
+
+		if err := a.ConvertToCSV(ctx, inputPath, outputPath); err != nil {
+			logger.WithError(err).Warn("Failed to convert file", logging.Field{Key: "file", Value: file.Name()})
+			continue
+		}
+		count++
+	}
+
+	logger.Info("Batch conversion complete", logging.Field{Key: "filesConverted", Value: count})
+	return count, nil
+}

--- a/internal/revolutcryptoparser/revolutcryptoparser.go
+++ b/internal/revolutcryptoparser/revolutcryptoparser.go
@@ -1,0 +1,261 @@
+// Package revolutcryptoparser parses Revolut Crypto account statement CSV files.
+// It handles French locale numbers ("69 924,87 CHF") and French locale dates
+// ("25 janv. 2026, 13:15:23"), converting them to standard Transaction models.
+package revolutcryptoparser
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"fjacquet/camt-csv/internal/logging"
+	"fjacquet/camt-csv/internal/models"
+	"fjacquet/camt-csv/internal/parsererror"
+
+	"github.com/shopspring/decimal"
+)
+
+// cryptoCSVRow represents one row in a Revolut Crypto account statement.
+type cryptoCSVRow struct {
+	Symbol   string
+	Type     string
+	Quantity string
+	Price    string
+	Value    string
+	Fees     string
+	Date     string
+}
+
+// frenchMonths maps French abbreviated month names to zero-padded month numbers.
+var frenchMonths = map[string]string{
+	"janv.": "01",
+	"févr.": "02",
+	"mars":  "03",
+	"avr.":  "04",
+	"mai":   "05",
+	"juin":  "06",
+	"juil.": "07",
+	"août":  "08",
+	"sept.": "09",
+	"oct.":  "10",
+	"nov.":  "11",
+	"déc.":  "12",
+}
+
+// parseFrenchDate parses a French locale date string like "25 janv. 2026, 13:15:23".
+func parseFrenchDate(s string) time.Time {
+	// Remove the comma after the year: "25 janv. 2026, 13:15:23" → "25 janv. 2026 13:15:23"
+	s = strings.ReplaceAll(s, ",", "")
+	parts := strings.Fields(s)
+	// Expected parts: ["25", "janv.", "2026", "13:15:23"]
+	if len(parts) != 4 {
+		return time.Time{}
+	}
+
+	month, ok := frenchMonths[parts[1]]
+	if !ok {
+		return time.Time{}
+	}
+
+	// Build ISO-like string: "2026-01-25 13:15:23"
+	normalized := fmt.Sprintf("%s-%s-%02s %s", parts[2], month, parts[0], parts[3])
+	t, err := time.ParseInLocation("2006-01-02 15:04:05", normalized, time.Local)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// parseFrenchAmount parses a French locale amount string like "69 924,87 CHF".
+// Returns (decimal.Zero, "") for empty input.
+func parseFrenchAmount(s string) (decimal.Decimal, string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return decimal.Zero, ""
+	}
+
+	// Extract trailing currency code (3 uppercase letters after a space)
+	currency := ""
+	if len(s) >= 4 {
+		last := s[len(s)-3:]
+		allAlpha := true
+		for _, c := range last {
+			if c < 'A' || c > 'Z' {
+				allAlpha = false
+				break
+			}
+		}
+		if allAlpha && s[len(s)-4] == ' ' {
+			currency = last
+			s = strings.TrimSpace(s[:len(s)-4])
+		}
+	}
+
+	// Remove thousands separator (space) and convert decimal separator (comma → dot)
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, ",", ".")
+
+	amount, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero, currency
+	}
+	return amount, currency
+}
+
+// ParseWithCategorizer parses a Revolut Crypto CSV reader and returns transactions.
+func ParseWithCategorizer(r io.Reader, logger logging.Logger, categorizer models.TransactionCategorizer) ([]models.Transaction, error) {
+	if logger == nil {
+		logger = logging.NewLogrusAdapter("info", "text")
+	}
+	logger.Info("Parsing Revolut Crypto CSV from reader")
+
+	reader := csv.NewReader(r)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CSV: %w", err)
+	}
+
+	if len(records) < 2 {
+		return nil, &parsererror.InvalidFormatError{
+			FilePath:       "(from reader)",
+			ExpectedFormat: "Revolut Crypto CSV",
+			Msg:            "CSV file is empty or contains only headers",
+		}
+	}
+
+	// Validate headers
+	expected := []string{"Symbol", "Type", "Quantity", "Price", "Value", "Fees", "Date"}
+	if len(records[0]) < len(expected) {
+		return nil, &parsererror.InvalidFormatError{
+			FilePath:       "(from reader)",
+			ExpectedFormat: "Revolut Crypto CSV",
+			Msg:            "CSV file has insufficient columns",
+		}
+	}
+	for i, h := range expected {
+		if strings.TrimSpace(records[0][i]) != h {
+			return nil, &parsererror.InvalidFormatError{
+				FilePath:       "(from reader)",
+				ExpectedFormat: "Revolut Crypto CSV",
+				Msg:            fmt.Sprintf("unexpected header at position %d: expected %q, got %q", i, h, strings.TrimSpace(records[0][i])),
+			}
+		}
+	}
+
+	var transactions []models.Transaction
+
+	for i, record := range records[1:] {
+		if len(record) < 7 {
+			logger.Warn("Skipping row: insufficient columns",
+				logging.Field{Key: "row", Value: i + 2})
+			continue
+		}
+
+		row := cryptoCSVRow{
+			Symbol:   strings.TrimSpace(record[0]),
+			Type:     strings.TrimSpace(record[1]),
+			Quantity: strings.TrimSpace(record[2]),
+			Price:    strings.TrimSpace(record[3]),
+			Value:    strings.TrimSpace(record[4]),
+			Fees:     strings.TrimSpace(record[5]),
+			Date:     strings.TrimSpace(record[6]),
+		}
+
+		tx, err := convertRowToTransaction(row)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to convert row to transaction",
+				logging.Field{Key: "row", Value: i + 2})
+			continue
+		}
+
+		if categorizer != nil {
+			isDebtor := tx.CreditDebit == models.TransactionTypeDebit
+			catDate := ""
+			if !tx.Date.IsZero() {
+				catDate = tx.Date.Format("02.01.2006")
+			}
+			category, catErr := categorizer.Categorize(context.Background(), tx.PartyName, isDebtor, tx.Amount.String(), catDate, "")
+			if catErr != nil {
+				logger.WithError(catErr).Warn("Failed to categorize transaction",
+					logging.Field{Key: "party", Value: tx.PartyName})
+				tx.Category = models.CategoryUncategorized
+			} else {
+				tx.Category = category.Name
+			}
+		} else {
+			tx.Category = models.CategoryUncategorized
+		}
+
+		transactions = append(transactions, tx)
+	}
+
+	logger.Info("Successfully parsed transactions from Revolut Crypto CSV",
+		logging.Field{Key: "count", Value: len(transactions)})
+	return transactions, nil
+}
+
+// convertRowToTransaction converts a cryptoCSVRow to a models.Transaction.
+func convertRowToTransaction(row cryptoCSVRow) (models.Transaction, error) {
+	date := parseFrenchDate(row.Date)
+	partyName := fmt.Sprintf("Revolut Crypto - %s", row.Symbol)
+
+	builder := models.NewTransactionBuilder().
+		WithDatetime(date).
+		WithValueDatetime(date).
+		WithPartyName(partyName).
+		WithType(row.Type).
+		WithFund(row.Symbol).
+		WithInvestment(row.Symbol)
+
+	switch {
+	case row.Type == "Achat":
+		amount, currency := parseFrenchAmount(row.Value)
+		if currency == "" {
+			currency = "CHF"
+		}
+		fees, _ := parseFrenchAmount(row.Fees)
+
+		description := fmt.Sprintf("Achat %s (%s %s)", row.Symbol, row.Quantity, row.Symbol)
+		builder = builder.
+			WithAmount(amount, currency).
+			WithFees(fees).
+			WithDescription(description).
+			WithPayee(partyName, "").
+			AsDebit()
+
+	case row.Type == "Récompense de staking":
+		// No CHF value — record the crypto quantity received as the amount in crypto currency
+		qty, _ := parseFrenchAmount(row.Quantity)
+		if qty.IsZero() {
+			qty = decimal.New(1, -8) // guard: builder rejects zero amount
+		}
+		description := fmt.Sprintf("Récompense de staking %s (%s %s)", row.Symbol, row.Quantity, row.Symbol)
+		builder = builder.
+			WithAmount(qty, row.Symbol).
+			WithDescription(description).
+			WithPayer(partyName, "").
+			AsCredit()
+
+	default:
+		// Unknown type: use Value if present, otherwise zero
+		amount, currency := parseFrenchAmount(row.Value)
+		if currency == "" {
+			currency = "CHF"
+		}
+		description := fmt.Sprintf("%s %s (%s %s)", row.Type, row.Symbol, row.Quantity, row.Symbol)
+		builder = builder.
+			WithAmount(amount, currency).
+			WithDescription(description).
+			WithPayee(partyName, "").
+			AsDebit()
+	}
+
+	tx, err := builder.Build()
+	if err != nil {
+		return models.Transaction{}, fmt.Errorf("error building transaction: %w", err)
+	}
+	return tx, nil
+}

--- a/internal/revolutcryptoparser/revolutcryptoparser_test.go
+++ b/internal/revolutcryptoparser/revolutcryptoparser_test.go
@@ -1,0 +1,331 @@
+package revolutcryptoparser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"fjacquet/camt-csv/internal/logging"
+	"fjacquet/camt-csv/internal/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock categorizer ---
+
+type mockCategorizer struct {
+	mock.Mock
+}
+
+func (m *mockCategorizer) Categorize(ctx context.Context, partyName string, isDebtor bool, amount, date, description string) (models.Category, error) {
+	args := m.Called(ctx, partyName, isDebtor, amount, date, description)
+	return args.Get(0).(models.Category), args.Error(1)
+}
+
+func newTestLogger() logging.Logger {
+	return logging.NewLogrusAdapter("info", "text")
+}
+
+func validCryptoCSV() string {
+	return `Symbol,Type,Quantity,Price,Value,Fees,Date
+BTC,Achat,"0,00014206","69 924,87 CHF","9,94 CHF","0,25 CHF","25 janv. 2026, 13:15:23"
+DOT,Récompense de staking,"0,00523871",,,,"15 mars 2026, 08:00:00"
+`
+}
+
+// --- parseFrenchDate tests ---
+
+func TestParseFrenchDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantZero bool
+		wantYear int
+		wantMon  time.Month
+		wantDay  int
+	}{
+		{"valid January", "25 janv. 2026, 13:15:23", false, 2026, time.January, 25},
+		{"valid March", "15 mars 2026, 08:00:00", false, 2026, time.March, 15},
+		{"valid December", "31 déc. 2025, 23:59:59", false, 2025, time.December, 31},
+		{"invalid month", "25 xyz. 2026, 13:15:23", true, 0, 0, 0},
+		{"too few parts", "25 janv. 2026", true, 0, 0, 0},
+		{"empty string", "", true, 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFrenchDate(tt.input)
+			if tt.wantZero {
+				assert.True(t, got.IsZero())
+			} else {
+				assert.Equal(t, tt.wantYear, got.Year())
+				assert.Equal(t, tt.wantMon, got.Month())
+				assert.Equal(t, tt.wantDay, got.Day())
+			}
+		})
+	}
+}
+
+// --- parseFrenchAmount tests ---
+
+func TestParseFrenchAmount(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantAmount   string
+		wantCurrency string
+	}{
+		{"with CHF", "69 924,87 CHF", "69924.87", "CHF"},
+		{"with EUR", "454,00 EUR", "454", "EUR"},
+		{"simple", "9,94 CHF", "9.94", "CHF"},
+		{"no currency", "123,45", "123.45", ""},
+		{"empty", "", "0", ""},
+		{"zero", "0,00 CHF", "0", "CHF"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			amount, currency := parseFrenchAmount(tt.input)
+			assert.Equal(t, tt.wantAmount, amount.String())
+			assert.Equal(t, tt.wantCurrency, currency)
+		})
+	}
+}
+
+// --- ParseWithCategorizer tests ---
+
+func TestParseWithCategorizer_ValidCSV(t *testing.T) {
+	logger := newTestLogger()
+	cat := &mockCategorizer{}
+	cat.On("Categorize", mock.Anything, "Revolut Crypto - BTC", true, mock.Anything, mock.Anything, mock.Anything).
+		Return(models.Category{Name: "Crypto"}, nil)
+	cat.On("Categorize", mock.Anything, "Revolut Crypto - DOT", false, mock.Anything, mock.Anything, mock.Anything).
+		Return(models.Category{Name: "Staking"}, nil)
+
+	transactions, err := ParseWithCategorizer(strings.NewReader(validCryptoCSV()), logger, cat)
+	require.NoError(t, err)
+	assert.Len(t, transactions, 2)
+
+	assert.Equal(t, "Crypto", transactions[0].Category)
+	assert.Contains(t, transactions[0].Description, "Achat BTC")
+	assert.Equal(t, "Revolut Crypto - BTC", transactions[0].PartyName)
+
+	assert.Equal(t, "Staking", transactions[1].Category)
+	assert.Contains(t, transactions[1].Description, "Récompense de staking DOT")
+
+	cat.AssertExpectations(t)
+}
+
+func TestParseWithCategorizer_NilCategorizer(t *testing.T) {
+	logger := newTestLogger()
+	transactions, err := ParseWithCategorizer(strings.NewReader(validCryptoCSV()), logger, nil)
+	require.NoError(t, err)
+	assert.Len(t, transactions, 2)
+	assert.Equal(t, models.CategoryUncategorized, transactions[0].Category)
+	assert.Equal(t, models.CategoryUncategorized, transactions[1].Category)
+}
+
+func TestParseWithCategorizer_CategorizerError(t *testing.T) {
+	logger := newTestLogger()
+	cat := &mockCategorizer{}
+	cat.On("Categorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(models.Category{}, fmt.Errorf("API error"))
+
+	transactions, err := ParseWithCategorizer(strings.NewReader(validCryptoCSV()), logger, cat)
+	require.NoError(t, err)
+	assert.Len(t, transactions, 2)
+	assert.Equal(t, models.CategoryUncategorized, transactions[0].Category)
+}
+
+func TestParseWithCategorizer_NilLogger(t *testing.T) {
+	transactions, err := ParseWithCategorizer(strings.NewReader(validCryptoCSV()), nil, nil)
+	require.NoError(t, err)
+	assert.Len(t, transactions, 2)
+}
+
+func TestParseWithCategorizer_EmptyCSV(t *testing.T) {
+	logger := newTestLogger()
+	_, err := ParseWithCategorizer(strings.NewReader("Symbol,Type,Quantity,Price,Value,Fees,Date\n"), logger, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestParseWithCategorizer_InvalidHeaders(t *testing.T) {
+	logger := newTestLogger()
+	csv := "A,B,C,D,E,F,G\n1,2,3,4,5,6,7\n"
+	_, err := ParseWithCategorizer(strings.NewReader(csv), logger, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected header")
+}
+
+func TestParseWithCategorizer_InsufficientColumns(t *testing.T) {
+	logger := newTestLogger()
+	csv := "A,B\n1,2\n"
+	_, err := ParseWithCategorizer(strings.NewReader(csv), logger, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient columns")
+}
+
+func TestParseWithCategorizer_ShortRowsCauseCSVError(t *testing.T) {
+	logger := newTestLogger()
+	// csv.ReadAll rejects rows with mismatched field counts
+	csv := "Symbol,Type,Quantity,Price,Value,Fees,Date\nBTC,Achat,0.1\n"
+	_, err := ParseWithCategorizer(strings.NewReader(csv), logger, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read CSV")
+}
+
+func TestParseWithCategorizer_UnknownType(t *testing.T) {
+	logger := newTestLogger()
+	csv := `Symbol,Type,Quantity,Price,Value,Fees,Date
+ETH,Vente,"1,0","3 000,00 CHF","3 000,00 CHF","0,50 CHF","10 févr. 2026, 14:00:00"
+`
+	transactions, err := ParseWithCategorizer(strings.NewReader(csv), logger, nil)
+	require.NoError(t, err)
+	assert.Len(t, transactions, 1)
+	assert.Contains(t, transactions[0].Description, "Vente ETH")
+}
+
+// --- convertRowToTransaction tests ---
+
+func TestConvertRowToTransaction_Achat(t *testing.T) {
+	row := cryptoCSVRow{
+		Symbol:   "BTC",
+		Type:     "Achat",
+		Quantity: "0,00014206",
+		Price:    "69 924,87 CHF",
+		Value:    "9,94 CHF",
+		Fees:     "0,25 CHF",
+		Date:     "25 janv. 2026, 13:15:23",
+	}
+	tx, err := convertRowToTransaction(row)
+	require.NoError(t, err)
+	assert.Equal(t, "Revolut Crypto - BTC", tx.PartyName)
+	assert.Equal(t, "CHF", tx.Currency)
+	assert.Equal(t, models.TransactionTypeDebit, tx.CreditDebit)
+	assert.Contains(t, tx.Description, "Achat BTC")
+}
+
+func TestConvertRowToTransaction_StakingReward(t *testing.T) {
+	row := cryptoCSVRow{
+		Symbol:   "DOT",
+		Type:     "Récompense de staking",
+		Quantity: "0,00523871",
+		Date:     "15 mars 2026, 08:00:00",
+	}
+	tx, err := convertRowToTransaction(row)
+	require.NoError(t, err)
+	assert.Equal(t, models.TransactionTypeCredit, tx.CreditDebit)
+	assert.Contains(t, tx.Description, "Récompense de staking DOT")
+}
+
+func TestConvertRowToTransaction_AchatNoCurrency(t *testing.T) {
+	row := cryptoCSVRow{
+		Symbol:   "ETH",
+		Type:     "Achat",
+		Quantity: "1,0",
+		Value:    "3000,50",
+		Fees:     "1,00",
+		Date:     "10 avr. 2026, 10:00:00",
+	}
+	tx, err := convertRowToTransaction(row)
+	require.NoError(t, err)
+	assert.Equal(t, "CHF", tx.Currency) // defaults to CHF
+}
+
+// --- Adapter tests ---
+
+func TestAdapter_ValidateFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Valid file
+	validPath := filepath.Join(tmpDir, "valid.csv")
+	err := os.WriteFile(validPath, []byte("Symbol,Type,Quantity,Price,Value,Fees,Date\nBTC,Achat,1,100,100,1,now\n"), 0600)
+	require.NoError(t, err)
+
+	adapter := NewAdapter(newTestLogger())
+	ok, err := adapter.ValidateFormat(validPath)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// Invalid file (wrong headers)
+	invalidPath := filepath.Join(tmpDir, "invalid.csv")
+	err = os.WriteFile(invalidPath, []byte("A,B,C\n1,2,3\n"), 0600)
+	require.NoError(t, err)
+	ok, err = adapter.ValidateFormat(invalidPath)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	// Non-existent file
+	ok, err = adapter.ValidateFormat(filepath.Join(tmpDir, "nope.csv"))
+	assert.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestAdapter_Parse(t *testing.T) {
+	adapter := NewAdapter(newTestLogger())
+	transactions, err := adapter.Parse(context.Background(), strings.NewReader(validCryptoCSV()))
+	require.NoError(t, err)
+	assert.Len(t, transactions, 2)
+}
+
+func TestAdapter_ConvertToCSV(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "input.csv")
+	outputPath := filepath.Join(tmpDir, "output.csv")
+
+	err := os.WriteFile(inputPath, []byte(validCryptoCSV()), 0600)
+	require.NoError(t, err)
+
+	adapter := NewAdapter(newTestLogger())
+	err = adapter.ConvertToCSV(context.Background(), inputPath, outputPath)
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "BTC")
+}
+
+func TestAdapter_BatchConvert(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputDir := filepath.Join(tmpDir, "input")
+	outputDir := filepath.Join(tmpDir, "output")
+	require.NoError(t, os.MkdirAll(inputDir, 0750))
+
+	// Write one valid file
+	err := os.WriteFile(filepath.Join(inputDir, "crypto.csv"), []byte(validCryptoCSV()), 0600)
+	require.NoError(t, err)
+
+	// Write one invalid file
+	err = os.WriteFile(filepath.Join(inputDir, "bad.csv"), []byte("not,a,valid,file\n"), 0600)
+	require.NoError(t, err)
+
+	adapter := NewAdapter(newTestLogger())
+	count, err := adapter.BatchConvert(context.Background(), inputDir, outputDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestAdapter_BatchConvert_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputDir := filepath.Join(tmpDir, "empty")
+	outputDir := filepath.Join(tmpDir, "output")
+	require.NoError(t, os.MkdirAll(inputDir, 0750))
+
+	adapter := NewAdapter(newTestLogger())
+	count, err := adapter.BatchConvert(context.Background(), inputDir, outputDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestAdapter_BatchConvert_InvalidInputDir(t *testing.T) {
+	adapter := NewAdapter(newTestLogger())
+	_, err := adapter.BatchConvert(context.Background(), "/nonexistent/dir", "/tmp/out")
+	assert.Error(t, err)
+}

--- a/internal/revolutinvestmentparser/revolutinvestmentparser.go
+++ b/internal/revolutinvestmentparser/revolutinvestmentparser.go
@@ -332,13 +332,29 @@ func convertRowToTransaction(row RevolutInvestmentCSVRow, logger logging.Logger)
 	return transaction, nil
 }
 
-// cleanAmountString removes currency symbols and formatting from amount strings
+// cleanAmountString removes currency symbols and codes from amount strings.
+// Handles both symbol prefixes (€, $, £) and ISO 4217 code prefixes (e.g. "USD 2.84").
 func cleanAmountString(amountStr string) string {
-	cleaned := strings.TrimPrefix(amountStr, "€")
-	cleaned = strings.TrimPrefix(cleaned, "$")
-	cleaned = strings.TrimPrefix(cleaned, "£")
-	cleaned = strings.ReplaceAll(cleaned, ",", "")
-	return cleaned
+	s := strings.TrimSpace(amountStr)
+	// Strip leading 3-letter currency code (e.g. "USD ", "EUR ", "CHF ")
+	if len(s) > 4 && s[3] == ' ' {
+		allAlpha := true
+		for _, c := range s[:3] {
+			if c < 'A' || c > 'Z' {
+				allAlpha = false
+				break
+			}
+		}
+		if allAlpha {
+			s = strings.TrimSpace(s[4:])
+		}
+	}
+	// Strip symbol prefixes
+	s = strings.TrimPrefix(s, "€")
+	s = strings.TrimPrefix(s, "$")
+	s = strings.TrimPrefix(s, "£")
+	s = strings.ReplaceAll(s, ",", "")
+	return strings.TrimSpace(s)
 }
 
 // formatDate parses the date string and returns time.Time

--- a/internal/revolutinvestmentparser/revolutinvestmentparser_test.go
+++ b/internal/revolutinvestmentparser/revolutinvestmentparser_test.go
@@ -456,6 +456,13 @@ func TestCleanAmountString(t *testing.T) {
 		{"1,000", "1000"},
 		{"500", "500"},
 		{"€1,234,567.89", "1234567.89"},
+		{"USD 2.84", "2.84"},
+		{"EUR 454", "454"},
+		{"CHF 1,234.56", "1234.56"},
+		{"  USD 100.00  ", "100.00"},
+		{"AB 100", "AB 100"},     // 2-letter code: not stripped
+		{"ABCD 100", "ABCD 100"}, // 4-letter code: not stripped
+		{"abc 100", "abc 100"},   // lowercase: not stripped
 	}
 
 	for _, test := range tests {

--- a/internal/revolutparser/revolutparser.go
+++ b/internal/revolutparser/revolutparser.go
@@ -48,6 +48,9 @@ func ParseWithCategorizer(r io.Reader, logger logging.Logger, categorizer models
 		return nil, fmt.Errorf("error reading input: %w", err)
 	}
 
+	// Normalize French-localized CSVs before validation and parsing
+	data = normalizeCSVData(data)
+
 	// Check if the file format is valid
 	valid, err := validateFormat(bytes.NewReader(data))
 	if err != nil {
@@ -238,6 +241,88 @@ func convertRevolutRowToTransaction(row RevolutCSVRow, logger logging.Logger) (m
 	return transaction, nil
 }
 
+// normalizeCSVData converts French-localized Revolut CSV headers and column values to English.
+// Normalization is column-aware: only Type, Product, and State columns are value-normalized,
+// so transaction descriptions are never altered.
+func normalizeCSVData(data []byte) []byte {
+	reader := csv.NewReader(bytes.NewReader(data))
+	records, err := reader.ReadAll()
+	if err != nil || len(records) == 0 {
+		return data
+	}
+
+	headerMap := map[string]string{
+		"Produit":       "Product",
+		"Date de début": "Started Date",
+		"Date de fin":   "Completed Date",
+		"Montant":       "Amount",
+		"Frais":         "Fee",
+		"Devise":        "Currency",
+		"État":          "State",
+		"Solde":         "Balance",
+	}
+	stateMap := map[string]string{
+		"TERMINÉ":    "COMPLETED",
+		"ANNULÉ":     "REVERTED",
+		"EN ATTENTE": "PENDING",
+		"DÉCLINÉ":    "DECLINED",
+		"RÉVISÉ":     "REVERTED",
+	}
+	typeMap := map[string]string{
+		"Paiement par carte":      "CARD_PAYMENT",
+		"Virement":                "TRANSFER",
+		"Changes":                 "EXCHANGE",
+		"Ajout de fonds":          "TOPUP",
+		"Remboursement des frais": "FEE_REFUND",
+		"Valider le paiement":     "CARD_PAYMENT",
+		"Retrait d'espèces":       "ATM",
+	}
+	productMap := map[string]string{
+		"Valeur actuelle": "CURRENT",
+		"Épargne":         "SAVINGS",
+	}
+
+	// Normalize headers and record column indices
+	colIndex := make(map[string]int)
+	for i, h := range records[0] {
+		if en, ok := headerMap[h]; ok {
+			records[0][i] = en
+			colIndex[en] = i
+		} else {
+			colIndex[h] = i
+		}
+	}
+
+	typeIdx, hasType := colIndex["Type"]
+	productIdx, hasProduct := colIndex["Product"]
+	stateIdx, hasState := colIndex["State"]
+
+	for _, row := range records[1:] {
+		if hasType && typeIdx < len(row) {
+			if en, ok := typeMap[row[typeIdx]]; ok {
+				row[typeIdx] = en
+			}
+		}
+		if hasProduct && productIdx < len(row) {
+			if en, ok := productMap[row[productIdx]]; ok {
+				row[productIdx] = en
+			}
+		}
+		if hasState && stateIdx < len(row) {
+			if en, ok := stateMap[row[stateIdx]]; ok {
+				row[stateIdx] = en
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	if err := w.WriteAll(records); err != nil {
+		return data
+	}
+	return buf.Bytes()
+}
+
 // validateFormat checks if the file is a valid Revolut CSV file.
 func validateFormat(r io.Reader) (bool, error) {
 	return validateFormatWithLogger(r, nil)
@@ -249,7 +334,17 @@ func validateFormatWithLogger(r io.Reader, logger logging.Logger) (bool, error) 
 	}
 	logger.Info("Validating Revolut CSV format from reader")
 
-	reader := csv.NewReader(r)
+	// Normalize French-localized CSVs before header validation
+	rawData, err := io.ReadAll(r)
+	if err != nil {
+		return false, &parsererror.ValidationError{
+			FilePath: "(from reader)",
+			Reason:   fmt.Sprintf("failed to read CSV data: %v", err),
+		}
+	}
+	normalizedData := normalizeCSVData(rawData)
+
+	reader := csv.NewReader(bytes.NewReader(normalizedData))
 
 	// Read header
 	header, err := reader.Read()

--- a/internal/revolutparser/revolutparser_test.go
+++ b/internal/revolutparser/revolutparser_test.go
@@ -596,3 +596,170 @@ CARD_PAYMENT,Current,2025-01-02 08:07:09,2025-01-03 15:38:51,Coffee,INVALID_AMOU
 		}
 	})
 }
+
+// --- normalizeCSVData tests ---
+
+func TestNormalizeCSVData_FrenchHeaders(t *testing.T) {
+	frenchCSV := "Type,Produit,Date de début,Date de fin,Description,Montant,Frais,Devise,État,Solde\n" +
+		"Paiement par carte,Valeur actuelle,2025-01-02 08:07:09,2025-01-03 15:38:51,Coffee,-10.50,0.00,CHF,TERMINÉ,100.00\n"
+
+	result := normalizeCSVData([]byte(frenchCSV))
+	resultStr := string(result)
+
+	assert.Contains(t, resultStr, "Product")
+	assert.Contains(t, resultStr, "Started Date")
+	assert.Contains(t, resultStr, "Completed Date")
+	assert.Contains(t, resultStr, "Amount")
+	assert.Contains(t, resultStr, "Fee")
+	assert.Contains(t, resultStr, "Currency")
+	assert.Contains(t, resultStr, "State")
+	assert.Contains(t, resultStr, "Balance")
+	assert.NotContains(t, resultStr, "Produit")
+	assert.NotContains(t, resultStr, "Montant")
+}
+
+func TestNormalizeCSVData_FrenchValues(t *testing.T) {
+	frenchCSV := "Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance\n" +
+		"Paiement par carte,Valeur actuelle,2025-01-02 08:07:09,2025-01-03 15:38:51,Coffee,-10.50,0.00,CHF,TERMINÉ,100.00\n"
+
+	result := normalizeCSVData([]byte(frenchCSV))
+	resultStr := string(result)
+
+	assert.Contains(t, resultStr, "CARD_PAYMENT")
+	assert.Contains(t, resultStr, "CURRENT")
+	assert.Contains(t, resultStr, "COMPLETED")
+	assert.NotContains(t, resultStr, "Paiement par carte")
+	assert.NotContains(t, resultStr, "TERMINÉ")
+}
+
+func TestNormalizeCSVData_AllFrenchTypes(t *testing.T) {
+	tests := []struct {
+		french  string
+		english string
+	}{
+		{"Paiement par carte", "CARD_PAYMENT"},
+		{"Virement", "TRANSFER"},
+		{"Changes", "EXCHANGE"},
+		{"Ajout de fonds", "TOPUP"},
+		{"Remboursement des frais", "FEE_REFUND"},
+		{"Retrait d'espèces", "ATM"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.french, func(t *testing.T) {
+			csv := "Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance\n" +
+				tt.french + ",Current,2025-01-02 08:07:09,2025-01-03 15:38:51,Test,-10.50,0.00,CHF,COMPLETED,100.00\n"
+			result := string(normalizeCSVData([]byte(csv)))
+			assert.Contains(t, result, tt.english)
+		})
+	}
+}
+
+func TestNormalizeCSVData_AllFrenchStates(t *testing.T) {
+	tests := []struct {
+		french  string
+		english string
+	}{
+		{"TERMINÉ", "COMPLETED"},
+		{"ANNULÉ", "REVERTED"},
+		{"EN ATTENTE", "PENDING"},
+		{"DÉCLINÉ", "DECLINED"},
+		{"RÉVISÉ", "REVERTED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.french, func(t *testing.T) {
+			csv := "Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance\n" +
+				"CARD_PAYMENT,Current,2025-01-02 08:07:09,2025-01-03 15:38:51,Test,-10.50,0.00,CHF," + tt.french + ",100.00\n"
+			result := string(normalizeCSVData([]byte(csv)))
+			assert.Contains(t, result, tt.english)
+		})
+	}
+}
+
+func TestNormalizeCSVData_FrenchProducts(t *testing.T) {
+	tests := []struct {
+		french  string
+		english string
+	}{
+		{"Valeur actuelle", "CURRENT"},
+		{"Épargne", "SAVINGS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.french, func(t *testing.T) {
+			csv := "Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance\n" +
+				"CARD_PAYMENT," + tt.french + ",2025-01-02 08:07:09,2025-01-03 15:38:51,Test,-10.50,0.00,CHF,COMPLETED,100.00\n"
+			result := string(normalizeCSVData([]byte(csv)))
+			assert.Contains(t, result, tt.english)
+		})
+	}
+}
+
+func TestNormalizeCSVData_EnglishPassthrough(t *testing.T) {
+	englishCSV := "Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance\n" +
+		"CARD_PAYMENT,Current,2025-01-02 08:07:09,2025-01-03 15:38:51,Coffee,-10.50,0.00,CHF,COMPLETED,100.00\n"
+
+	result := normalizeCSVData([]byte(englishCSV))
+	// Description should not be altered
+	assert.Contains(t, string(result), "Coffee")
+	assert.Contains(t, string(result), "CARD_PAYMENT")
+}
+
+func TestNormalizeCSVData_InvalidCSV(t *testing.T) {
+	invalidCSV := []byte("not\"valid,csv\n")
+	result := normalizeCSVData(invalidCSV)
+	// Should return original data on parse error
+	assert.Equal(t, invalidCSV, result)
+}
+
+func TestNormalizeCSVData_EmptyInput(t *testing.T) {
+	result := normalizeCSVData([]byte{})
+	assert.Equal(t, []byte{}, result)
+}
+
+func TestNormalizeCSVData_DescriptionNotAltered(t *testing.T) {
+	// French descriptions should NOT be normalized
+	csv := "Type,Produit,Date de début,Date de fin,Description,Montant,Frais,Devise,État,Solde\n" +
+		"Paiement par carte,Valeur actuelle,2025-01-02,2025-01-03,Épicerie du village,-50.00,0.00,CHF,TERMINÉ,200.00\n"
+	result := string(normalizeCSVData([]byte(csv)))
+	assert.Contains(t, result, "Épicerie du village") // description preserved
+	assert.Contains(t, result, "CARD_PAYMENT")        // type normalized
+}
+
+func TestValidateFormat_FrenchCSV(t *testing.T) {
+	frenchCSV := "Type,Produit,Date de début,Date de fin,Description,Montant,Frais,Devise,État,Solde\n" +
+		"Paiement par carte,Valeur actuelle,2025-01-02 08:07:09,2025-01-03 15:38:51,Coffee,-10.50,0.00,CHF,TERMINÉ,100.00\n"
+
+	valid, err := validateFormat(strings.NewReader(frenchCSV))
+	assert.NoError(t, err)
+	assert.True(t, valid, "French-localized CSV should be accepted after normalization")
+}
+
+func TestParseWithCategorizer_FrenchCSV(t *testing.T) {
+	logger := logging.NewLogrusAdapter("info", "text")
+	frenchCSV := "Type,Produit,Date de début,Date de fin,Description,Montant,Frais,Devise,État,Solde\n" +
+		"Paiement par carte,Valeur actuelle,2025-01-02 08:07:09,2025-01-03 15:38:51,Coffee Shop,-10.50,0.00,CHF,TERMINÉ,100.00\n"
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "revolut_fr.csv")
+	err := os.WriteFile(tmpFile, []byte(frenchCSV), 0600)
+	require.NoError(t, err)
+
+	file, err := os.Open(tmpFile)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			t.Logf("Failed to close file: %v", closeErr)
+		}
+	}()
+
+	data, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	data = normalizeCSVData(data)
+
+	transactions, err := ParseWithCategorizer(strings.NewReader(string(data)), logger, nil)
+	assert.NoError(t, err)
+	assert.Len(t, transactions, 1)
+	assert.Equal(t, "Coffee Shop", transactions[0].Description)
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"fjacquet/camt-csv/cmd/debit"
 	"fjacquet/camt-csv/cmd/pdf"
 	"fjacquet/camt-csv/cmd/revolut"
+	revolutcrypto "fjacquet/camt-csv/cmd/revolut-crypto"
 	revolutinvestment "fjacquet/camt-csv/cmd/revolut-investment"
 	"fjacquet/camt-csv/cmd/root"
 	"fjacquet/camt-csv/cmd/selma"
@@ -46,6 +47,7 @@ func init() {
 	root.Cmd.AddCommand(pdf.Cmd)
 	root.Cmd.AddCommand(selma.Cmd)
 	root.Cmd.AddCommand(revolut.Cmd)
+	root.Cmd.AddCommand(revolutcrypto.Cmd)
 	root.Cmd.AddCommand(debit.Cmd)
 	root.Cmd.AddCommand(revolutinvestment.Cmd)
 }


### PR DESCRIPTION
## Summary

- Add new `revolut-crypto` command for parsing Revolut Crypto account statement CSV exports (French locale numbers/dates, supports `Achat` and `Récompense de staking` transaction types)
- Add French-localized CSV normalization to the `revolut` parser — French-exported headers and values are transparently converted to English before parsing
- Fix `revolut-investment` parser failing on amounts with ISO 4217 currency code prefix (e.g. `USD 2.84`)
- Fix `revolut` command ignoring config-level `output.format` when `--format` flag is omitted
- Update all docs (README, user guide, PRD, architecture, CLAUDE.md, changelog) for v2.4.0 release

## Test plan

- [x] All 3054 tests pass
- [x] `golangci-lint` reports 0 issues
- [x] Build succeeds on Go 1.24+
- [ ] CI pipeline passes (CodeQL, tests, lint)
- [ ] After merge: tag `v2.4.0` and create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Revolut Crypto CSV import and new revolut-crypto command with French locale handling (dates/numbers)
  * Extended Revolut CSV support to accept French-localized exports (header/value normalization)
  * Expanded payee/merchant categorization mappings for Revolut and other payees

* **Bug Fixes**
  * Investment parser handles ISO currency-prefixed amounts (e.g., USD 2.84)
  * Revolut command now respects configured output format when no --format flag provided

* **Documentation**
  * README, user guide, and docs updated to include Revolut Crypto CSV and usage examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->