### PR TITLE
ci: make `security` advisory (match central default)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ sbom:
 	go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@$(CYCLONEDX_GOMOD_VERSION) mod -json -output $(DIST)/sbom.cdx.json
 
 ## security: Run Semgrep SAST (canonical Go security scanner)
-security:
-	uvx semgrep scan --config auto --error --skip-unknown-extensions
+security:  # advisory: reports findings but never blocks the build (CodeQL/osv are the blocking gates)
+	uvx semgrep scan --config auto --skip-unknown-extensions || true
 
 ## docs: Build MkDocs documentation
 docs:


### PR DESCRIPTION
Change the blocking `make security` target to advisory: it reports Semgrep findings but never fails the build. CodeQL and osv-scanner remain the blocking security gates.

Before: `uvx semgrep scan --config auto --error --skip-unknown-extensions` (blocking)
After: `uvx semgrep scan --config auto --skip-unknown-extensions || true` (advisory)

Verified `make security` exits 0 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H28tbCKQauHg4pX5ebCXi