### PR TITLE
docs(readme): add standard status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CAMT-CSV
 
+[![License](https://img.shields.io/github/license/fjacquet/camt-csv)](https://github.com/fjacquet/camt-csv/blob/HEAD/LICENSE)
+
 > Convert financial statements to CSV with intelligent transaction categorization
 
 [![Go CI](https://github.com/fjacquet/camt-csv/actions/workflows/ci.yml/badge.svg)](https://github.com/fjacquet/camt-csv/actions/workflows/ci.yml)


### PR DESCRIPTION
Adds the standard README badge set (CI + latest release + license where applicable) to match the rest of the fleet. Docs-only.