### PR TITLE
chore: bump go directive to 1.26.4 (clear stdlib CVE gate)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module fjacquet/camt-csv
 
-go 1.24.13
+go 1.26.4
 
 require (
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1


### PR DESCRIPTION
camt-csv builds with an outdated Go stdlib, so `make vuln` (govulncheck) fails on standard-library CVEs already patched upstream (GO-2026-5039/5037/4971/4947/4946, fixed in go1.25.9–1.25.11 / 1.26.x). This bumps the `go` directive from `1.24.13` to the fleet-standard `1.26.4`, clearing the vuln gate. Unblocks Dependabot #18 once it rebases onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->